### PR TITLE
PHPCS ruleset formatting

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="Block Scaffolding Coding Standards">
+	<arg name="extensions" value="php" />
+	<arg name="colors" />
+	<arg value="s" /><!-- Show sniff codes in all reports -->
+
 	<rule ref="WordPress-Core">
 		<exclude name="WordPress.Files.FileName" />
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
@@ -7,14 +11,11 @@
 
 	<rule ref="WordPress-Docs"></rule>
 
-
-	<arg name="extensions" value="php" />
-	<arg name="colors" />
-	<arg value="s" /><!-- Show sniff codes in all reports -->
 	<rule ref="PHPCompatibilityWP" />
 	<config name="testVersion" value="5.6-" />
 
 	<file>.</file>
+
 	<exclude-pattern>/node_modules/</exclude-pattern>
 	<exclude-pattern>/vendor/</exclude-pattern>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,12 +7,12 @@
 
 	<rule ref="WordPress-Docs"></rule>
 
-    <rule ref="PHPCompatibilityWP"/>
-	<config name="testVersion" value="5.6-"/>
 
 	<arg name="extensions" value="php" />
 	<arg name="colors" />
 	<arg value="s" /><!-- Show sniff codes in all reports -->
+	<rule ref="PHPCompatibilityWP" />
+	<config name="testVersion" value="5.6-" />
 
 	<file>.</file>
 	<exclude-pattern>/node_modules/</exclude-pattern>


### PR DESCRIPTION
- Use tabs everywhere per `.editorconfig`.
- Self-close XML tags per spec.
- Move global `phpcs` args to the top of the file for visibility.