### PR TITLE
Automerge minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "extends": [
-    "config:base",
-    ":preserveSemverRanges"
+    "config:base"
+  ],
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Reduce Renovate noise. Should be a fine strategy for a scaffolding repository.