### PR TITLE
Use correct function to get plugin meta

### DIFF
--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -169,7 +169,7 @@ class Plugin {
 		static $meta;
 
 		if ( ! isset( $meta ) ) {
-			$meta = get_file_data( $this->file );
+			$meta = get_plugin_data( $this->file );
 		}
 
 		if ( isset( $field ) ) {


### PR DESCRIPTION
Using [`get_file_data`](https://developer.wordpress.org/reference/functions/get_file_data/) requires a default set of default headers to also be passed. The correct function to use here would be [`get_plugin_data`](https://developer.wordpress.org/reference/functions/get_plugin_data/), which has those headers already set.